### PR TITLE
#6. Added automatic version management using GitVersion

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -3,7 +3,12 @@
 
 name: .NET
 
-on: [push]
+on:
+  push:
+    branches: [ "main" ]
+
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -14,14 +19,31 @@ jobs:
             dotnet-version: [ '7.0.x' ]
 
     steps:
-    - uses: actions/checkout@v3
+
     - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
+        fetch-depth: 0
+
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0
+      with:
+        versionSpec: '5.x'
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Restore dependencies
       run: dotnet restore
+
+    - name: Determine Version
+      uses: gittools/actions/gitversion/execute@v0
+      with:
+        useConfigFile: true
+
     - name: Build
       run: dotnet build --configuration Release --no-restore
+
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -20,19 +20,20 @@ jobs:
 
     steps:
 
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
-        fetch-depth: 0
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0
       with:
         versionSpec: '5.x'
-
-    - name: Checkout
-      uses: actions/checkout@v3
 
     - name: Restore dependencies
       run: dotnet restore

--- a/Bach.sln
+++ b/Bach.sln
@@ -11,6 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bach.Cli", "src\Bach.Cli\Ba
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8AFA9D67-FBA4-4F3E-A750-712C0D85C26D}"
 	ProjectSection(SolutionItems) = preProject
+		GitVersion.yml = GitVersion.yml
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
@@ -23,6 +24,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{96AE218D-B0C4-4722-A756-85333B1FC799}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\BuildAndTest.yml = .github\workflows\BuildAndTest.yml
+		.github\workflows\CacheDotNet.yml = .github\workflows\CacheDotNet.yml
 	EndProjectSection
 EndProject
 Global

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,10 @@
+mode: Mainline
+next-version: 0.7.0
+assembly-versioning-scheme: MajorMinorPatch
+assembly-informational-format: '{Major}.{Minor}.{Patch}{PreReleaseTagWithDash}+{CommitDate}.{ShortSha}'
+assembly-file-versioning-scheme: MajorMinorPatch
+commit-date-format: yyMMdd
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}


### PR DESCRIPTION
[GitVersion](https://gitversion.net/docs/) generates a [Semantic Version number](https://semver.org/) based on the Git history.

We use a [MainLine](https://gitversion.net/docs/reference/modes/mainline) development mode for versioning. This mode is great if you do not want to tag each release because you simply deploy every commit to **_main_**. The behavior of this mode is as follows:

1. Calculate a base version (likely a tag in this mode)
2. Walk all commits from the base version commit
3. When a merge commit is found:
    * Calculate increments for each direct commit on **_main_**
    * Calculate the increment for the branch
4. Calculate increments for each remaining direct commit
5. For feature branches, calculate increment for the commits so far on your feature branch.

Version numbers can be manually incremented using the `+semver:` stage in a commit message. Adding `+semver: breaking` or `+semver: major` will cause the major version to be incremented, `+semver: feature` or `+semver: minor` will increment the 
minor version, and `+semver: patch` or `+semver: fix` will increment the patch version number.

The format for the informational version number is: **_{Major}.{Minor}.{Patch}{PreReleaseTagWithDash}+{CommitDate}.{ShortSha}_**.

See [GitVersion.yml](GitVersion.yml) for GitVersion's configuration details.

Closes #6.
